### PR TITLE
QLA-56 fixed method for getting img url

### DIFF
--- a/services/kupay_cart_service.php
+++ b/services/kupay_cart_service.php
@@ -268,25 +268,6 @@ class KupayCartService
         }
     }
 
-    // private static function getProductImage($id_product)
-    // {
-
-    //     try {
-
-    //         $product = new Product((int)$id_product);
-
-    //         $img = $product->getCover($product->id);
-
-    //         $image_name = $product->link_rewrite[count($product->link_rewrite) - 1];
-
-
-    //         return  Context::getContext()->link->getImageLink($image_name, (int)$img['id_image'], "medium_default");
-    //     } catch (Exception $e) {
-
-    //         return "https://user-images.githubusercontent.com/101482/29592647-40da86ca-875a-11e7-8bc3-941700b0a323.png";
-    //     }
-    // }
-
     public static function calculateCartShipping(Cart $cart): float
     {
 


### PR DESCRIPTION
Added a verification to check if there are images related to the attribute id of a certain product. If there are no images, we go and retrieve the cover image of the product. Also, if there are no variations for the product (id_product_attribute = 0), we also go for the cover image.

_Commented the getProductImage function._