### PR TITLE
QLA-26 fixed retrieve method and GET req method

### DIFF
--- a/controllers/front/cart.php
+++ b/controllers/front/cart.php
@@ -67,7 +67,6 @@ class KupayCartModuleFrontController extends ModuleFrontController
     protected function processGetRequest() {
 
         try {
-            $payload = json_decode(Tools::file_get_contents('php://input'), true);
             $url = $_SERVER['REQUEST_URI'];
             $url = parse_url($url);
             parse_str($url['query'], $params);
@@ -82,7 +81,7 @@ class KupayCartModuleFrontController extends ModuleFrontController
             }
             $code = $params['code'];
 
-            $cart = KupayCartService::retrieve($code, $payload);
+            $cart = KupayCartService::retrieve($code);
 
             $this->ajaxRender(json_encode($cart));
 

--- a/services/kupay_cart_service.php
+++ b/services/kupay_cart_service.php
@@ -84,9 +84,10 @@ class KupayCartService
     /**
      * @throws PrestaShopException
      */
-    public static function retrieve($cart, $payload): array
+    public static function retrieve($cart): array
     {
         $cart = new Cart($cart);
+        $payload = [];
 
         return self::buildCartData($cart, $payload);
     }
@@ -169,15 +170,16 @@ class KupayCartService
      */
     private static function buildCartData(Cart $cart, $payload): array
     {
-
-        $country = new Country(Country::getByIso($payload['shopper']['shippingAddress']['countryCode']));
+        if (isset($payload['shopper'])) {
+            $country = new Country(Country::getByIso($payload['shopper']['shippingAddress']['countryCode']));
+        }
 
         return [
             'code' => (string) $cart->id,
-            'origin' => $payload['origin'],
-            'shopper' => $payload['shopper'],
+            'origin' => isset($payload['origin']) ? $payload['origin'] : NULL,
+            'shopper' => isset($payload['shopper']) ? $payload['shopper'] : NULL,
             'items' => self::getCartProducts($cart),
-            'shippingMethods' => self::getCartShippingMethods($cart, $country),
+            'shippingMethods' => isset($payload['shopper']) ? self::getCartShippingMethods($cart, $country) : NULL,
             'coupons' => self::getCartCoupons($cart),
             'totals' => self::getCartTotals($cart)
         ];


### PR DESCRIPTION
Fixed _retrieve_ method on the **kupay_cart_service.php** file and modified the _processGetRequest()_ method to receive only the Cart ID as a **$code**. The final result on the _retrieve_ method should only return an array with the cart information, its items and total price.