### PR TITLE
QLA-167 add the output of exec cmd in NewRelic log

### DIFF
--- a/services/kupay_update_service.php
+++ b/services/kupay_update_service.php
@@ -50,7 +50,7 @@ class KupayUpdateService
                 exec($cmd, $output, $retval);
             }
 
-            KupayLogService::logNewRelic("INFO", "Execution of command in bg (on $os): " . $cmd, "update");
+            KupayLogService::logNewRelic("INFO", "Execution of command in bg (on $os): " . $cmd . " | Output: " . $output[0], "update");
 
         } catch (Exception $e) {
 


### PR DESCRIPTION
Added the line _(string)_ of the output that the exec command returns when executed.