### PR TITLE
QLA-167 add more info to log on NewRelic for exec

### DIFF
--- a/kupay.php
+++ b/kupay.php
@@ -292,6 +292,10 @@ class Kupay extends Module
                     $output = $this->displayError($this->l('There was en error when trying to update the module.'));
                     break;
 
+                case '':
+                    $output = $this->displayWarning($this->l('The update process could not be completed. Please contact the Qoala support.'));
+                    break;
+
                 default:
                     $output = $this->displayInformation($this->l("Module has a new update! Go to Module Catalog and click on 'Upgrade' on the Qoala Module."));
                     break;

--- a/services/kupay_update_service.php
+++ b/services/kupay_update_service.php
@@ -49,8 +49,18 @@ class KupayUpdateService
                 $os = 'Linux/Unix';
                 exec($cmd, $output, $retval);
             }
+            
+            $outputString = "";
 
-            KupayLogService::logNewRelic("INFO", "Execution of command in bg (on $os): " . $cmd . " | Output: " . $output[0], "update");
+            if (count($output) > 1) {
+                foreach ($output as $value) {
+                    $outputString .= $value . " - ";
+                }
+            } else {
+                $outputString = $output[0];
+            }
+
+            KupayLogService::logNewRelic("INFO", "Execution of command in bg (on $os): " . $cmd . " | Output: " . $outputString, "update");
 
         } catch (Exception $e) {
 


### PR DESCRIPTION
Added a message in the case where the output is empty ('') and a message will be displayed:

-  $output = $this->displayWarning($this->l('The update process could not be completed. Please contact the Qoala support.'));

_This message can be modified of course._

- created a variable to store the information of the output if it's have more than one line of information after the execution of the commands.