### PR TITLE
fix quickview modal price bug - update version

### DIFF
--- a/kupay.php
+++ b/kupay.php
@@ -39,7 +39,7 @@ class Kupay extends Module
     {
         $this->name = 'kupay';
         $this->tab = 'front_office_features';
-        $this->version = '1.2.1';
+        $this->version = '1.2.2';
         $this->author = 'Qoala';
         $this->need_instance = 0;
 

--- a/views/js/kupay.js
+++ b/views/js/kupay.js
@@ -153,7 +153,9 @@ async function kupayPdpQuickviewCheckout() {
 
     // Get Product price
     let price = document.getElementsByClassName('current-price-value')[0];
-    price = parseFloat(price.innerHTML.trim().substring(1));
+    price = price.innerHTML.trim().slice(0, -7);
+    price = parseFloat(price.replace('.', '').replace(/,/g, '.'));
+    console.log('price:', price);
 
     let iframeUrl = kupay.iframeUrl;
 


### PR DESCRIPTION
Originally, the price of the product in the quickview modal is taken from an inner `span`. Changes were made because the value was `NaN` and the price in the url for the `kupay-checkout` was `NaN`. Now it should send the price as a `float` number.
Also, version of Prestashop module is upgraded from `1.2.1` to `1.2.2`